### PR TITLE
Add condition for ios and android compatibility

### DIFF
--- a/BabyTrackerFrontEnd/page/Datetime1.js
+++ b/BabyTrackerFrontEnd/page/Datetime1.js
@@ -5,6 +5,7 @@ import {
   Text,
   View,
   TouchableOpacity,
+  Button,
 } from 'react-native';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { useNavigation } from '@react-navigation/native';
@@ -15,10 +16,14 @@ export default function DateTime1() {
   // for First Date Time Picker=======================================
   const [date1, setDate1] = useState(new Date());
   const [time1, setTime1] = useState(new Date(Date.now()));
+  const [datePicker1, setDatePicker1] = useState(false);
+  const [timePicker1, setTimePicker1] = useState(false);
 
   // for Second Date Time Picker=======================================
   const [date2, setDate2] = useState(new Date(date1.getTime() + 5 * 86400000));
   const [time2, setTime2] = useState(new Date(Date.now()));
+  const [datePicker2, setDatePicker2] = useState(false);
+  const [timePicker2, setTimePicker2] = useState(false);
 
   // Function for First Date Time Picker================================
   function showDatePicker1() {
@@ -51,7 +56,7 @@ export default function DateTime1() {
     setTimePicker2(false);
   }
   //========================================================================
-  return (
+  return Platform.OS === 'ios' ? (
     <SafeAreaView
       style={{
         width: '100%',
@@ -141,6 +146,124 @@ export default function DateTime1() {
         </View>
       </View>
     </SafeAreaView>
+  ) : (
+    <SafeAreaView
+      style={{
+        width: '100%',
+        height: '100%',
+      }}
+    >
+      <View style={{ width: '100%', height: '100%' }}>
+        <View style={{ paddingLeft: 25, paddingTop: 25 }}>
+          <TouchableOpacity
+            style={{}}
+            onPress={() => navigation.navigate('Stopwatch')}
+          >
+            <Text style={{}}>Back</Text>
+          </TouchableOpacity>
+        </View>
+        {/* First Date Time Picker ====================================================*/}
+        <View style={[styleSheet.MainContainer, { padding: 25 }]}>
+          <Text style={styleSheet.text}>Date = {date1.toDateString()}</Text>
+
+          <Text style={styleSheet.text}>
+            Time = {time1.toLocaleTimeString('en-US')}
+          </Text>
+
+          {datePicker1 && (
+            <DateTimePicker
+              value={date1}
+              mode={'date'}
+              display={Platform.OS === 'ios' ? 'spinner' : 'default'}
+              is24Hour={true}
+              onChange={onDateSelected1}
+              style={styleSheet.datePicker1}
+            />
+          )}
+
+          {timePicker1 && (
+            <DateTimePicker
+              value={time1}
+              mode={'time'}
+              display={Platform.OS === 'ios' ? 'spinner' : 'default'}
+              is24Hour={false}
+              onChange={onTimeSelected1}
+              style={styleSheet.datePicker1}
+            />
+          )}
+
+          {!datePicker1 && (
+            <View style={{ margin: 10 }}>
+              <Button
+                title="Show Date Picker"
+                color="green"
+                onPress={showDatePicker1}
+              />
+            </View>
+          )}
+
+          {!timePicker1 && (
+            <View style={{ margin: 10 }}>
+              <Button
+                title="Show Time Picker"
+                color="green"
+                onPress={showTimePicker1}
+              />
+            </View>
+          )}
+        </View>
+
+        {/* Second Date Time Picker ====================================================*/}
+        <View style={[styleSheet.MainContainer, { padding: 25 }]}>
+          <Text style={styleSheet.text}>Date = {date2.toDateString()}</Text>
+
+          <Text style={styleSheet.text}>
+            Time = {time2.toLocaleTimeString('en-US')}
+          </Text>
+
+          {datePicker2 && (
+            <DateTimePicker
+              value={date2}
+              mode={'date'}
+              display={Platform.OS === 'ios' ? 'spinner' : 'default'}
+              is24Hour={true}
+              onChange={onDateSelected2}
+              style={styleSheet.datePicker2}
+            />
+          )}
+          {timePicker2 && (
+            <DateTimePicker
+              value={time2}
+              mode={'time'}
+              display={Platform.OS === 'ios' ? 'spinner' : 'default'}
+              is24Hour={false}
+              onChange={onTimeSelected2}
+              style={styleSheet.datePicker2}
+            />
+          )}
+
+          {!datePicker2 && (
+            <View style={{ margin: 10 }}>
+              <Button
+                title="Show Date Picker"
+                color="green"
+                onPress={showDatePicker2}
+              />
+            </View>
+          )}
+
+          {!timePicker2 && (
+            <View style={{ margin: 10 }}>
+              <Button
+                title="Show Time Picker"
+                color="green"
+                onPress={showTimePicker2}
+              />
+            </View>
+          )}
+        </View>
+      </View>
+    </SafeAreaView>
   );
 }
 
@@ -162,5 +285,20 @@ const styleSheet = StyleSheet.create({
     alignItems: 'center',
     width: 100,
     height: 50,
+  },
+  datePicker1: {
+    justifyContent: 'center',
+    alignItems: 'flex-start',
+    width: 320,
+    height: 260,
+    display: 'flex',
+    textAlign: 'center',
+  },
+  datePicker2: {
+    justifyContent: 'center',
+    alignItems: 'flex-start',
+    width: 320,
+    height: 260,
+    display: 'flex',
   },
 });


### PR DESCRIPTION
Android didn't run last time because how the DateTimePicker works in android is different from iOS (at least from iOS 14 and after)

The previous version with buttons is readded back for Android and the current one is still there for iOS only.

Android:
![image](https://user-images.githubusercontent.com/94136126/221390135-70f35572-431f-41d3-812b-4c736b9dc24a.png)

iOS:
![image](https://user-images.githubusercontent.com/94136126/221390145-de9110c7-7906-419d-81fc-0936801d160a.png)

Yes the UI is as barebone as possible but this branch is for a major Android compatibility issue that needs to be fixed first before any other implementations towards it (UI, other functionalities, ...)